### PR TITLE
CMakeLists.txt: Update minimum version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 project(libpacket C)
 add_subdirectory(src)
 


### PR DESCRIPTION
Fix this compatibility error reported by modern CMake versions:
 "Compatibility with CMake < 3.5 has been removed from CMake"

I've picked 3.12 because that is already specified in the tests/CMakeLists.txt.